### PR TITLE
Fix Rule Typo

### DIFF
--- a/yara/cn_pentestset_webshells.yar
+++ b/yara/cn_pentestset_webshells.yar
@@ -741,7 +741,8 @@ rule CN_Honker_Webshell_Tuoku_script_mysql {
 		hash = "8e242c40aabba48687cfb135b51848af4f2d389d"
 	strings:
 		$s1 = "txtpassword.Attributes.Add(\"onkeydown\", \"SubmitKeyClick('btnLogin');\");" fullword ascii /* PEStudio Blacklist: strings */
-		$s2 = "connString = string.Format(\"Host = {0}; UserName = {1}; Password = {2}; Databas" ascii /* PEStudio Blacklist: strings */condition:
+		$s2 = "connString = string.Format(\"Host = {0}; UserName = {1}; Password = {2}; Databas" ascii /* PEStudio Blacklist: strings */
+	condition:
 		filesize < 202KB and all of them
 }
 


### PR DESCRIPTION
A rule's condition header needed a newline to make the rule syntactically correct.